### PR TITLE
feat(parques): modify service, controller, mapper and tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,6 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
     </dependencies>
-
     <build>
         <plugins>
             <plugin>

--- a/src/main/java/sv/edu/udb/service/ParqueService.java
+++ b/src/main/java/sv/edu/udb/service/ParqueService.java
@@ -1,12 +1,14 @@
 package sv.edu.udb.service;
 
-import sv.edu.udb.domain.Parque;
+import sv.edu.udb.web.dto.request.ParqueRequest;
+import sv.edu.udb.web.dto.response.ParqueResponse;
+
 import java.util.List;
 
 public interface ParqueService {
-    List<Parque> findAll();
-    Parque findById(Long id);
-    Parque create(Parque p);
-    Parque update(Long id, Parque p);
+    List<ParqueResponse> findAll();
+    ParqueResponse findById(Long id);
+    ParqueResponse save(ParqueRequest request);
+    ParqueResponse update(Long id, ParqueRequest request);
     void delete(Long id);
 }

--- a/src/main/java/sv/edu/udb/service/impl/ParqueServiceImpl.java
+++ b/src/main/java/sv/edu/udb/service/impl/ParqueServiceImpl.java
@@ -1,34 +1,60 @@
 package sv.edu.udb.service.impl;
 
 import jakarta.persistence.EntityNotFoundException;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import sv.edu.udb.domain.Parque;
 import sv.edu.udb.repository.ParqueRepository;
 import sv.edu.udb.service.ParqueService;
+import sv.edu.udb.web.dto.request.ParqueRequest;
+import sv.edu.udb.web.dto.response.ParqueResponse;
+import sv.edu.udb.web.mapper.ParqueMapper;
 
 import java.util.List;
 
-@Service @Transactional
+@Service
+@RequiredArgsConstructor
 public class ParqueServiceImpl implements ParqueService {
-    private final ParqueRepository repo;
-    public ParqueServiceImpl(ParqueRepository repo) { this.repo = repo; }
 
-    @Override @Transactional(readOnly = true)
-    public List<Parque> findAll() { return repo.findAll(); }
+    @NonNull
+    private final ParqueRepository parqueRepository;
 
-    @Override @Transactional(readOnly = true)
-    public Parque findById(Long id) { return repo.findById(id).orElseThrow(() -> new EntityNotFoundException("Parque no encontrado: " + id)); }
+    @NonNull
+    private final ParqueMapper parqueMapper;
 
-    @Override public Parque create(Parque p) { if (p.getId()!=null) p.setId(null); return repo.save(p); }
-    @Override public Parque update(Long id, Parque p) {
-        Parque current = findById(id);
-        current.setNombre(p.getNombre());
-        current.setDistrito(p.getDistrito());
-        current.setAreaHa(p.getAreaHa());
-        current.setLat(p.getLat());
-        current.setLon(p.getLon());
-        return repo.save(current);
+
+    @Override
+    public List<ParqueResponse> findAll() {
+        return parqueMapper.toParqueResponseList(parqueRepository.findAll());
     }
-    @Override public void delete(Long id) { if (!repo.existsById(id)) throw new EntityNotFoundException("Parque no encontrado: " + id); repo.deleteById(id); }
+
+    @Override
+    public ParqueResponse findById(final Long id) {
+        final Parque entity = parqueRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(("Parque no encontrado id " + id)));
+        return parqueMapper.toResponse(entity);
+    }
+
+    @Override
+    public ParqueResponse save(final ParqueRequest request) {
+        final Parque entity = parqueMapper.toEntity(request);
+        return parqueMapper.toResponse(parqueRepository.save(entity));
+    }
+
+    @Override
+    public ParqueResponse update(final Long id, final ParqueRequest request) {
+        final Parque current = parqueRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Parque no encontrado id " + id));
+
+        parqueMapper.update(current, request);
+
+        return parqueMapper.toResponse(parqueRepository.save(current));
+    }
+
+    @Override
+    public void delete(final Long id) {
+        parqueRepository.deleteById(id);
+    }
 }

--- a/src/main/java/sv/edu/udb/web/controller/ParqueController.java
+++ b/src/main/java/sv/edu/udb/web/controller/ParqueController.java
@@ -1,57 +1,49 @@
 package sv.edu.udb.web.controller;
 
 import jakarta.validation.Valid;
-import org.springframework.http.ResponseEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
-import sv.edu.udb.domain.Parque;
 import sv.edu.udb.service.ParqueService;
 import sv.edu.udb.web.dto.request.ParqueRequest;
 import sv.edu.udb.web.dto.response.ParqueResponse;
-import sv.edu.udb.web.mapper.ParqueMapper;
 
-import java.net.URI;
 import java.util.List;
 
+import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
+
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/parques")
 public class ParqueController {
 
     private final ParqueService service;
-    private final ParqueMapper mapper;
-
-    public ParqueController(ParqueService service, ParqueMapper mapper) {
-        this.service = service;
-        this.mapper = mapper;
-    }
 
     @GetMapping
-    public List<ParqueResponse> list() {
-        return service.findAll().stream().map(mapper::toResponse).toList();
+    public List<ParqueResponse> findAll() {
+        return service.findAll();
     }
 
-    @GetMapping("/{id}")
-    public ParqueResponse get(@PathVariable Long id) {
-        return mapper.toResponse(service.findById(id));
+    @GetMapping("{id}")
+    public ParqueResponse findById(@PathVariable Long id) {
+        return service.findById(id);
     }
 
     @PostMapping
-    public ResponseEntity<ParqueResponse> create(@Valid @RequestBody ParqueRequest req) {
-        Parque saved = service.create(mapper.toEntity(req));
-        return ResponseEntity
-                .created(URI.create("/api/parques/" + saved.getId()))
-                .body(mapper.toResponse(saved));
+    @ResponseStatus(CREATED)
+    public ParqueResponse save(@Valid @RequestBody ParqueRequest req) {
+        return service.save(req);
     }
 
-    @PutMapping("/{id}")
+    @PutMapping("{id}")
     public ParqueResponse update(@PathVariable Long id, @Valid @RequestBody ParqueRequest req) {
-        Parque current = service.findById(id);
-        mapper.update(current, req);
-        return mapper.toResponse(service.update(id, current));
+        return service.update(id, req);
     }
 
-    @DeleteMapping("/{id}")
-    public ResponseEntity<Void> delete(@PathVariable Long id) {
+    @DeleteMapping("{id}")
+    @ResponseStatus(NO_CONTENT)
+    public void delete(@PathVariable Long id) {
         service.delete(id);
-        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/sv/edu/udb/web/mapper/ParqueMapper.java
+++ b/src/main/java/sv/edu/udb/web/mapper/ParqueMapper.java
@@ -5,20 +5,21 @@ import sv.edu.udb.domain.Parque;
 import sv.edu.udb.web.dto.request.ParqueRequest;
 import sv.edu.udb.web.dto.response.ParqueResponse;
 
+import java.util.List;
+
 @Mapper(componentModel = "spring")
 public interface ParqueMapper {
 
-    /* Request -> Entity */
     @Mappings({
             @Mapping(target = "id", ignore = true),
-            // lo ignoramos al crear para que use el default Instant.now()
             @Mapping(target = "creadoEn", ignore = true)
     })
     Parque toEntity(ParqueRequest request);
 
-    /* Update */
     void update(@MappingTarget Parque target, ParqueRequest request);
 
-    /* Entity -> Response */
+    List<ParqueResponse> toParqueResponseList(final List<Parque> parqueList);
+
     ParqueResponse toResponse(Parque entity);
 }
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,3 @@
 spring.application.name=urban_carbon
-spring.profiles.active=local
+spring.profiles.active=dev
 springdoc.api-docs.path=/api-docs

--- a/src/test/java/sv/edu/udb/web/mapper/ParqueMapperTest.java
+++ b/src/test/java/sv/edu/udb/web/mapper/ParqueMapperTest.java
@@ -1,0 +1,124 @@
+package sv.edu.udb.web.mapper;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+import sv.edu.udb.domain.Parque;
+import sv.edu.udb.web.dto.request.ParqueRequest;
+import sv.edu.udb.web.dto.response.ParqueResponse;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ParqueMapperTest {
+
+    private ParqueMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        mapper = Mappers.getMapper(ParqueMapper.class);
+        assertNotNull(mapper, "Mapper no debe ser null");
+    }
+
+    @Test
+    void toEntity_ignoraIdYCreadoEn_yMapeaCampos() {
+        // Arrange
+        ParqueRequest req = new ParqueRequest();
+        req.setNombre("Central");
+        req.setDistrito("D1");
+        req.setAreaHa(2.5);
+        req.setLat(10.1);
+        req.setLon(20.2);
+
+        // Act
+        Parque out = mapper.toEntity(req);
+
+        // Assert
+        assertNotNull(out);
+        assertNull(out.getId(), "id debe quedar null (ignore=true)");
+        assertEquals("Central", out.getNombre());
+        assertEquals("D1", out.getDistrito());
+        assertEquals(2.5, out.getAreaHa());
+        assertEquals(10.1, out.getLat());
+        assertEquals(20.2, out.getLon());
+        // creadoEn lo ignora el mapper; en tu entidad se inicializa con Instant.now()
+        assertNotNull(out.getCreadoEn(), "creadoEn debería tener un valor por defecto de la entidad");
+    }
+
+    @Test
+    void update_putReemplazoTotal_nullPisaTarget() {
+        // Arrange (target con valores iniciales)
+        Parque target = new Parque();
+        target.setId(99L);
+        target.setNombre("Viejo");
+        target.setDistrito("D0");
+        target.setAreaHa(1.0);
+        target.setLat(5.0);
+        target.setLon(6.0);
+        Instant creado = target.getCreadoEn(); // debe preservarse, el mapper no lo toca
+
+        // Request con algunos nulls (PUT estricto: SET_TO_NULL → deben volverse null en target)
+        ParqueRequest req = new ParqueRequest();
+        req.setNombre("Nuevo");
+        req.setDistrito(null);      // → debe quedar null
+        req.setAreaHa(7.7);
+        req.setLat(null);           // → debe quedar null
+        req.setLon(8.8);
+
+        // Act
+        mapper.update(target, req);
+
+        // Assert
+        assertEquals(99L, target.getId(), "id no lo toca el mapper update");
+        assertEquals("Nuevo", target.getNombre());
+        assertNull(target.getDistrito(), "PUT: null del request debe pisar a null");
+        assertEquals(7.7, target.getAreaHa());
+        assertNull(target.getLat(), "PUT: null del request debe pisar a null");
+        assertEquals(8.8, target.getLon());
+        assertEquals(creado, target.getCreadoEn(), "creadoEn no debe ser modificado por el mapper");
+    }
+
+    @Test
+    void toResponse_mapeaCamposBasicos() {
+        // Arrange
+        Parque entity = new Parque();
+        entity.setId(1L);
+        entity.setNombre("Parque X");
+        entity.setDistrito("D9");
+        entity.setAreaHa(9.9);
+        entity.setLat(1.1);
+        entity.setLon(2.2);
+
+        // Act
+        ParqueResponse out = mapper.toResponse(entity);
+
+        // Assert
+        assertNotNull(out);
+        assertEquals(1L, out.getId());
+        assertEquals("Parque X", out.getNombre());
+        assertEquals("D9", out.getDistrito());
+        assertEquals(9.9, out.getAreaHa());
+        assertEquals(1.1, out.getLat());
+        assertEquals(2.2, out.getLon());
+    }
+
+    @Test
+    void toParqueResponseList_mapeaLista() {
+        // Arrange
+        Parque p1 = new Parque(); p1.setId(1L); p1.setNombre("A"); p1.setDistrito("D1"); p1.setAreaHa(1.0);
+        Parque p2 = new Parque(); p2.setId(2L); p2.setNombre("B"); p2.setDistrito("D2"); p2.setAreaHa(2.0);
+
+        // Act
+        List<ParqueResponse> out = mapper.toParqueResponseList(List.of(p1, p2));
+
+        // Assert
+        assertNotNull(out);
+        assertEquals(2, out.size());
+        assertEquals(1L, out.get(0).getId());
+        assertEquals("A", out.get(0).getNombre());
+        assertEquals(2L, out.get(1).getId());
+        assertEquals("B", out.get(1).getNombre());
+    }
+}


### PR DESCRIPTION
Se modificó todo lo relacionado a los parques, el servicio, el mapper, el controlador y algunos tests. Se agregó el test de ParqueMapperTest.

Todo esto fue para quitar la lógica de programación del controlador y pasar a usar el mapper directamente con el servicio