### PR TITLE
feat(especies): refactor mapper, service, controller and tests

### DIFF
--- a/src/main/java/sv/edu/udb/service/EspecieService.java
+++ b/src/main/java/sv/edu/udb/service/EspecieService.java
@@ -1,12 +1,15 @@
 package sv.edu.udb.service;
 
 import sv.edu.udb.domain.Especie;
+import sv.edu.udb.web.dto.request.EspecieRequest;
+import sv.edu.udb.web.dto.response.EspecieResponse;
+
 import java.util.List;
 
 public interface EspecieService {
-    List<Especie> findAll();
-    Especie findById(Long id);
-    Especie create(Especie e);
-    Especie update(Long id, Especie e);
+    List<EspecieResponse> findAll();
+    EspecieResponse findById(Long id);
+    EspecieResponse save(EspecieRequest e);
+    EspecieResponse update(Long id, EspecieRequest e);
     void delete(Long id);
 }

--- a/src/main/java/sv/edu/udb/service/impl/ParqueServiceImpl.java
+++ b/src/main/java/sv/edu/udb/service/impl/ParqueServiceImpl.java
@@ -55,6 +55,9 @@ public class ParqueServiceImpl implements ParqueService {
 
     @Override
     public void delete(final Long id) {
+        if (!parqueRepository.existsById(id)) {
+            throw new EntityNotFoundException("Especie no encontrada id " + id);
+        }
         parqueRepository.deleteById(id);
     }
 }

--- a/src/main/java/sv/edu/udb/web/controller/EspecieController.java
+++ b/src/main/java/sv/edu/udb/web/controller/EspecieController.java
@@ -1,58 +1,48 @@
 package sv.edu.udb.web.controller;
 
 import jakarta.validation.Valid;
-import org.springframework.http.ResponseEntity;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
-import sv.edu.udb.domain.Especie;
 import sv.edu.udb.service.EspecieService;
 import sv.edu.udb.web.dto.request.EspecieRequest;
 import sv.edu.udb.web.dto.response.EspecieResponse;
-import sv.edu.udb.web.mapper.EspecieMapper;
 
-import java.net.URI;
 import java.util.List;
 
+import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
+
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/especies")
 public class EspecieController {
 
     private final EspecieService service;
-    private final EspecieMapper mapper;
-
-    public EspecieController(EspecieService service, EspecieMapper mapper) {
-        this.service = service;
-        this.mapper = mapper;
-    }
 
     @GetMapping
     public List<EspecieResponse> list() {
-        return service.findAll().stream().map(mapper::toResponse).toList();
+        return service.findAll();
     }
 
     @GetMapping("/{id}")
     public EspecieResponse get(@PathVariable Long id) {
-        return mapper.toResponse(service.findById(id));
+        return service.findById(id);
     }
 
     @PostMapping
-    public ResponseEntity<EspecieResponse> create(@Valid @RequestBody EspecieRequest req) {
-        Especie toSave = mapper.toEntity(req);
-        Especie saved = service.create(toSave);
-        return ResponseEntity
-                .created(URI.create("/api/especies/" + saved.getId()))
-                .body(mapper.toResponse(saved));
+    @ResponseStatus(CREATED)
+    public EspecieResponse create(@Valid @RequestBody EspecieRequest req) {
+        return service.save(req);
     }
 
-    @PutMapping("/{id}")
+    @PutMapping("{id}")
     public EspecieResponse update(@PathVariable Long id, @Valid @RequestBody EspecieRequest req) {
-        Especie current = service.findById(id);
-        mapper.update(current, req);
-        return mapper.toResponse(service.update(id, current));
+        return service.update(id, req);
     }
 
-    @DeleteMapping("/{id}")
-    public ResponseEntity<Void> delete(@PathVariable Long id) {
+    @DeleteMapping("{id}")
+    @ResponseStatus(NO_CONTENT)
+    public void delete(@PathVariable Long id) {
         service.delete(id);
-        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/sv/edu/udb/web/controller/ParqueController.java
+++ b/src/main/java/sv/edu/udb/web/controller/ParqueController.java
@@ -2,7 +2,6 @@ package sv.edu.udb.web.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import sv.edu.udb.service.ParqueService;
 import sv.edu.udb.web.dto.request.ParqueRequest;

--- a/src/main/java/sv/edu/udb/web/dto/request/EspecieRequest.java
+++ b/src/main/java/sv/edu/udb/web/dto/request/EspecieRequest.java
@@ -11,9 +11,19 @@ import java.math.BigDecimal;
 @Getter
 @Setter
 public class EspecieRequest {
-    @NotBlank private String nombreCientifico;
+
+    @NotBlank
+    private String nombreCientifico;
     private String nombreComun;
-    @NotNull @DecimalMin("0.10") @DecimalMax("1.50") private BigDecimal densidadMaderaRho;
-    @NotBlank private String fuenteRho;
-    @NotBlank private String versionRho;
+
+    @NotNull
+    @DecimalMin("0.10")
+    @DecimalMax("1.50")
+    private BigDecimal densidadMaderaRho;
+
+    @NotBlank
+    private String fuenteRho;
+
+    @NotBlank
+    private String versionRho;
 }

--- a/src/main/java/sv/edu/udb/web/mapper/EspecieMapper.java
+++ b/src/main/java/sv/edu/udb/web/mapper/EspecieMapper.java
@@ -1,21 +1,23 @@
 package sv.edu.udb.web.mapper;
 
 import org.mapstruct.*;
-import org.mapstruct.factory.Mappers;
 import sv.edu.udb.domain.Especie;
 import sv.edu.udb.web.dto.request.EspecieRequest;
 import sv.edu.udb.web.dto.response.EspecieResponse;
 
+
+import java.util.List;
+
 @Mapper(componentModel = "spring")
 public interface EspecieMapper {
 
-    /* Request -> Entity */
     @Mapping(target = "id", ignore = true)
     Especie toEntity(EspecieRequest request);
 
-    /* Update */
+    @Mapping(target = "id", ignore = true)
     void update(@MappingTarget Especie target, EspecieRequest request);
 
-    /* Entity -> Response */
+    List<EspecieResponse> toEspecieResponseList(final List<Especie> especieList);
+
     EspecieResponse toResponse(Especie entity);
 }

--- a/src/main/java/sv/edu/udb/web/mapper/ParqueMapper.java
+++ b/src/main/java/sv/edu/udb/web/mapper/ParqueMapper.java
@@ -14,7 +14,8 @@ public interface ParqueMapper {
     @Mapping(target = "creadoEn", ignore = true)
     Parque toEntity(ParqueRequest request);
 
-    @BeanMapping(unmappedTargetPolicy = ReportingPolicy.IGNORE)
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "creadoEn", ignore = true)
     void update(@MappingTarget Parque target, ParqueRequest request);
 
     List<ParqueResponse> toParqueResponseList(final List<Parque> parqueList);

--- a/src/test/java/sv/edu/udb/service/EspecieServiceImplTest.java
+++ b/src/test/java/sv/edu/udb/service/EspecieServiceImplTest.java
@@ -3,12 +3,14 @@ package sv.edu.udb.service;
 import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.*;
 import sv.edu.udb.domain.Especie;
 import sv.edu.udb.repository.EspecieRepository;
+import sv.edu.udb.repository.ParqueRepository;
 import sv.edu.udb.service.impl.EspecieServiceImpl;
+import sv.edu.udb.web.dto.request.EspecieRequest;
+import sv.edu.udb.web.dto.response.EspecieResponse;
+import sv.edu.udb.web.mapper.EspecieMapper;
 
 import java.util.List;
 import java.util.Optional;
@@ -17,95 +19,135 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 class EspecieServiceImplTest {
-    @Mock private EspecieRepository repository;
+
+    @Mock private EspecieRepository especieRepository;
+    @Mock private EspecieMapper especieMapper;
+    @Mock private ParqueRepository parqueRepository; // ← tu service lo usa en delete()
 
     @InjectMocks private EspecieServiceImpl service;
 
     @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-    }
+    void setUp() { MockitoAnnotations.openMocks(this); }
 
     @Test
     void findAll_ok_devuelveLista() {
         // Arrange
-        when(repository.findAll()).thenReturn(List.of(new Especie()));
+        Especie e = new Especie();
+        when(especieRepository.findAll()).thenReturn(List.of(e));
+        when(especieMapper.toEspecieResponseList(anyList()))
+                .thenReturn(List.of(EspecieResponse.builder().id(1L).build()));
 
         // Act
         var out = service.findAll();
 
         // Assert
         assertEquals(1, out.size());
-        verify(repository).findAll();
+        verify(especieRepository).findAll();
+        verify(especieMapper).toEspecieResponseList(anyList());
     }
 
     @Test
-    void findById_ok_devuelveEntidad() {
+    void findById_ok_devuelveResponse() {
         // Arrange
-        Especie e = new Especie();
-        e.setId(1L);
-        when(repository.findById(1L)).thenReturn(Optional.of(e));
+        Especie e = new Especie(); e.setId(1L);
+        when(especieRepository.findById(1L)).thenReturn(Optional.of(e));
+        when(especieMapper.toResponse(e)).thenReturn(EspecieResponse.builder().id(1L).build());
 
         // Act
         var out = service.findById(1L);
 
         // Assert
         assertEquals(1L, out.getId());
-        verify(repository).findById(1L);
+        verify(especieRepository).findById(1L);
+        verify(especieMapper).toResponse(e);
     }
 
     @Test
     void findById_notFound_lanzaEntityNotFound() {
         // Arrange
-        when(repository.findById(99L)).thenReturn(Optional.empty());
+        when(especieRepository.findById(99L)).thenReturn(Optional.empty());
 
         // Act + Assert
         assertThrows(EntityNotFoundException.class, () -> service.findById(99L));
-        verify(repository).findById(99L);
+        verify(especieRepository).findById(99L);
+        verifyNoInteractions(especieMapper);
     }
 
     @Test
-    void create_ok_guardaYDevuelve() {
+    void save_ok_guardaYDevuelve() {
         // Arrange
-        Especie e = new Especie();
-        when(repository.save(e)).thenReturn(e);
+        EspecieRequest req = new EspecieRequest();
+        Especie entity = new Especie();
+        Especie saved = new Especie(); saved.setId(10L);
+        EspecieResponse res = EspecieResponse.builder().id(10L).build();
+
+        when(especieMapper.toEntity(req)).thenReturn(entity);
+        when(especieRepository.save(entity)).thenReturn(saved);
+        when(especieMapper.toResponse(saved)).thenReturn(res);
 
         // Act
-        var out = service.create(e);
+        var out = service.save(req);
 
         // Assert
         assertNotNull(out);
-        verify(repository).save(e);
+        assertEquals(10L, out.getId());
+        verify(especieMapper).toEntity(req);
+        verify(especieRepository).save(entity);
+        verify(especieMapper).toResponse(saved);
     }
 
     @Test
     void update_ok_actualizaExistente() {
         // Arrange
-        Especie existente = new Especie();
-        existente.setId(5L);
-        when(repository.findById(5L)).thenReturn(Optional.of(existente));
-        Especie cambios = new Especie();
-        when(repository.save(any(Especie.class))).thenAnswer(a -> a.getArgument(0));
+        Long id = 5L;
+        Especie current = new Especie(); current.setId(id);
+        EspecieRequest req = new EspecieRequest();
+        EspecieResponse res = EspecieResponse.builder().id(id).build();
+
+        when(especieRepository.findById(id)).thenReturn(Optional.of(current));
+        // mapper.update(...) es void; solo verificamos la invocación
+        when(especieRepository.save(current)).thenReturn(current);
+        when(especieMapper.toResponse(current)).thenReturn(res);
 
         // Act
-        var out = service.update(5L, cambios);
+        var out = service.update(id, req);
 
         // Assert
         assertNotNull(out);
-        verify(repository).findById(5L);
-        verify(repository).save(any(Especie.class));
+        assertEquals(id, out.getId());
+        verify(especieRepository).findById(id);
+        verify(especieMapper).update(current, req);
+        verify(especieRepository).save(current);
+        verify(especieMapper).toResponse(current);
     }
 
     @Test
     void delete_ok_invocaRepositorio() {
         // Arrange
-        when(repository.existsById(7L)).thenReturn(true);
-        doNothing().when(repository).deleteById(7L);
+        when(especieRepository.existsById(7L)).thenReturn(true);
+        doNothing().when(especieRepository).deleteById(7L);
 
         // Act
         service.delete(7L);
 
         // Assert
-        verify(repository).deleteById(7L);
+        verify(especieRepository).existsById(7L);
+        verify(especieRepository).deleteById(7L);
+        verifyNoMoreInteractions(especieRepository);
+        verifyNoInteractions(especieMapper);
     }
+
+    @Test
+    void delete_notFound_lanzaEntityNotFound() {
+        // Arrange
+        when(especieRepository.existsById(999L)).thenReturn(false);
+
+        // Act + Assert
+        assertThrows(EntityNotFoundException.class, () -> service.delete(999L));
+
+        verify(especieRepository).existsById(999L);
+        verifyNoMoreInteractions(especieRepository);
+        verifyNoInteractions(especieMapper);
+    }
+
 }

--- a/src/test/java/sv/edu/udb/service/ParqueServiceImplTest.java
+++ b/src/test/java/sv/edu/udb/service/ParqueServiceImplTest.java
@@ -124,14 +124,30 @@ class ParqueServiceImplTest {
     @Test
     void delete_ok_invocaRepositorio() {
         // Arrange
+        when(repository.existsById(7L)).thenReturn(true);
         doNothing().when(repository).deleteById(7L);
 
         // Act
         service.delete(7L);
 
         // Assert
+        verify(repository).existsById(7L);
         verify(repository).deleteById(7L);
         verifyNoMoreInteractions(repository);
         verifyNoInteractions(mapper);
     }
+
+    @Test
+    void delete_notFound_lanzaEntityNotFound() {
+        // Arrange
+        when(repository.existsById(7L)).thenReturn(false);
+
+        // Act + Assert
+        assertThrows(EntityNotFoundException.class, () -> service.delete(7L));
+
+        verify(repository).existsById(7L);
+        verifyNoMoreInteractions(repository);
+        verifyNoInteractions(mapper);
+    }
+
 }

--- a/src/test/java/sv/edu/udb/web/controller/ParqueControllerTest.java
+++ b/src/test/java/sv/edu/udb/web/controller/ParqueControllerTest.java
@@ -108,12 +108,15 @@ class ParqueControllerTest {
                 .andExpect(jsonPath("$.nombre").value("PGet"));
     }
 
-    @Test @DisplayName("DELETE /api/parques/{id} - elimina y retorna 204")
+    @Test @DisplayName("DELETE /api/parques/{id} - elimina y retorna 204, 404 si se repitio")
     void delete_ok() throws Exception {
         Parque p = new Parque(); p.setNombre("PDel"); p.setDistrito("DDel"); p.setAreaHa(1.0);
         p = parqueRepo.save(p);
 
         mvc.perform(delete("/api/parques/{id}", p.getId()))
                 .andExpect(status().isNoContent());
+
+        mvc.perform(delete("/api/parques/{id}", p.getId()))
+                .andExpect(status().isNotFound());
     }
 }

--- a/src/test/java/sv/edu/udb/web/mapper/EspecieMapperTest.java
+++ b/src/test/java/sv/edu/udb/web/mapper/EspecieMapperTest.java
@@ -29,6 +29,22 @@ class EspecieMapperTest {
     }
 
     @Test
+    void toEspecieResponseList_ok_mapeaLista() {
+        Especie e1 = new Especie(); e1.setId(1L); e1.setNombreCientifico("A"); e1.setNombreComun("CA");
+        Especie e2 = new Especie(); e2.setId(2L); e2.setNombreCientifico("B"); e2.setNombreComun("CB");
+
+        var out = mapper.toEspecieResponseList(java.util.List.of(e1, e2));
+
+        assertNotNull(out);
+        assertEquals(2, out.size());
+        assertEquals(1L, out.get(0).getId());
+        assertEquals("A", out.get(0).getNombreCientifico());
+        assertEquals(2L, out.get(1).getId());
+        assertEquals("B", out.get(1).getNombreCientifico());
+    }
+
+
+    @Test
     void update_ok_actualizaCamposDesdeRequest() {
         // Arrange
         Especie target = new Especie();
@@ -69,4 +85,26 @@ class EspecieMapperTest {
         assertEquals("Caoba", r.getNombreComun());
 
     }
+
+    @Test
+    void update_put_nullDebePisarValor() {
+        // Arrange
+        Especie target = new Especie();
+        target.setId(7L);
+        target.setNombreCientifico("Viejo");
+        target.setNombreComun("ViejoC");
+
+        EspecieRequest req = new EspecieRequest();
+        req.setNombreCientifico(null); // ← debe volverse null en target
+        req.setNombreComun("NuevoC");
+
+        // Act
+        mapper.update(target, req);
+
+        // Assert
+        assertEquals(7L, target.getId());
+        assertNull(target.getNombreCientifico(), "PUT: null del request debe pisar el valor");
+        assertEquals("NuevoC", target.getNombreComun());
+    }
+
 }


### PR DESCRIPTION
- EspecieMapper: se agregó @Mapping(ignore) para id, y método para listas.
- Service ahora trabaja directamente con DTOs (request/response) en lugar de entidades.
- Controller simplificado: se eliminó lógica de programación, delega en service.
- Tests actualizados (unitarios e integración) en base a los cambios en mapper, service y controlador.